### PR TITLE
WS-21: Update workflow to put documentation in repo docs/ directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,11 @@ Terraform-managed AWS ECS Fargate infrastructure configured for Free Tier usage.
 │   ├── check-free-tier.py
 │   └── cost-monitor.py
 ├── docs/                     # Technical documentation
+│   ├── technical-specs/
+│   ├── research/
 │   ├── architecture/
-│   ├── runbooks/
-│   └── decisions/            # ADRs
+│   ├── ADR/                  # Architecture Decision Records
+│   └── runbooks/
 ├── docker/                   # Container definitions
 └── .github/workflows/        # CI/CD automation
 ```
@@ -30,22 +32,23 @@ Terraform-managed AWS ECS Fargate infrastructure configured for Free Tier usage.
 ## Documentation Strategy
 
 ### Documentation Types and Locations
-- **Technical specs**: `docs/` directory in source control
+- **Technical specs**: `docs/technical-specs/` directory in source control
 - **Task management**: JIRA tickets for status tracking
-- **Research/spikes**: Confluence wiki pages for evaluation
-- **Architecture decisions**: `docs/decisions/` as ADR files
+- **Research/spikes**: `docs/research/` directory in source control
+- **Architecture decisions**: `docs/ADR/` as ADR files
+- **Architecture design**: `docs/architecture/` directory
 - **Operational procedures**: `docs/runbooks/`
 
 ### Documentation Workflow
-1. **Research phase**: Document findings in Confluence "Software Development" space under `ecs-fargate-infra` page tree
-2. **Design phase**: Create technical docs in `docs/architecture/`
-3. **Implementation**: Update docs during development
-4. **Operations**: Maintain runbooks in `docs/runbooks/`
+1. **Research phase**: Document findings in `docs/research/` using YYYY-MM-topic format
+2. **Technical Design**: Create specs in `docs/technical-specs/` and architecture in `docs/architecture/`
+3. **Architecture Decisions**: Record as ADRs in `docs/ADR/` using sequential numbering
+4. **Implementation**: Update docs during development
+5. **Operations**: Maintain runbooks in `docs/runbooks/`
 
 ### Tool Configuration
 - **GitHub**: Use `gh` CLI with `awynne` account for repository operations
 - **JIRA**: Use MCP server integration with WebStore project for task management
-- **Confluence**: Use Atlassian MCP with "Software Development" space, repo-specific page tree: `ecs-fargate-infra`
 - **Documentation**: Use context7 MCP for language syntax and framework documentation
 
 ## Prerequisites
@@ -393,11 +396,12 @@ gh pr create --title "WS-123: Configure load balancer" --body "Part 2 of ECS ser
 - No secrets detection
 
 ### Documentation Creation Process
-1. **Research**: Create Confluence page in "Software Development" space under `ecs-fargate-infra/research/`
-2. **Technical Design**: Document in `docs/architecture/` with ADRs in `docs/decisions/`
-3. **Task Management**: Create JIRA tickets in WebStore project for implementation tracking
-4. **Code Changes**: Use `gh` CLI with `awynne` account for PR creation and management
-5. **Language/Framework Questions**: Query context7 MCP for syntax and best practices
+1. **Research**: Document findings in `docs/research/` using YYYY-MM-topic naming convention
+2. **Technical Design**: Create specs in `docs/technical-specs/` and architecture docs in `docs/architecture/`
+3. **Architecture Decisions**: Record as ADRs in `docs/ADR/` with sequential numbering
+4. **Task Management**: Create JIRA tickets in WebStore project for implementation tracking
+5. **Code Changes**: Use `gh` CLI with `awynne` account for PR creation and management
+6. **Language/Framework Questions**: Query context7 MCP for syntax and best practices
 
 ### Cost Management Checklist
 - [ ] Verify Free Tier eligibility  

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,41 @@
+# Architecture Decision Records (ADRs)
+
+Records of architectural decisions made during the project.
+
+## ADR Index
+
+*ADRs will be listed here as they are created.*
+
+## Numbering Convention
+
+ADRs are numbered sequentially: `0001-decision-title.md`
+
+## ADR Template
+
+Use the template below for new ADRs:
+
+```markdown
+# ADR-XXXX: [Title]
+
+## Status
+[Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-YYYY]
+
+## Context
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+What is the change that we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult to do because of this change?
+
+## References
+- Links to related discussions, documents, or ADRs
+```
+
+## Creating New ADRs
+
+1. Copy [template.md](template.md)
+2. Number sequentially (check existing ADRs for next number)
+3. Fill out all sections
+4. Link from this README once accepted

--- a/docs/ADR/template.md
+++ b/docs/ADR/template.md
@@ -1,0 +1,16 @@
+# ADR-XXXX: [Decision Title]
+
+## Status
+[Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-YYYY]
+
+## Context
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+What is the change that we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult to do because of this change?
+
+## References
+- Links to related discussions, documents, or ADRs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# Documentation
+
+This directory contains all project documentation for the ECS Fargate Infrastructure project.
+
+## Structure
+
+- **[technical-specs/](technical-specs/)** - Technical specifications and feature documentation
+- **[research/](research/)** - Research findings, spikes, and evaluation results  
+- **[architecture/](architecture/)** - System architecture, diagrams, and design documents
+- **[ADR/](ADR/)** - Architecture Decision Records
+- **[runbooks/](runbooks/)** - Operational procedures and troubleshooting guides
+
+## Documentation Guidelines
+
+- Use markdown for all documentation
+- Link between pages using relative markdown links
+- Keep filenames consistent (use hyphens, no spaces)
+- Include README.md as index files for directories
+- Store images in `assets/images/` subdirectories
+
+## Linking Examples
+
+```markdown
+<!-- Link to other pages -->
+[Getting Started](technical-specs/getting-started.md)
+[Architecture Overview](architecture/README.md)
+[Deployment Guide](runbooks/deployment.md)
+
+<!-- Link to sections within pages -->
+[Authentication](technical-specs/authentication.md#bearer-tokens)
+
+<!-- Images -->
+![Architecture Diagram](assets/images/architecture.png)
+```

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,21 @@
+# Architecture
+
+System architecture, diagrams, and design documents.
+
+## Architecture Documents
+
+*Architecture documents will be added here as they are created.*
+
+## Planned Documents
+
+- **system-overview.md** - High-level system architecture
+- **component-diagram.md** - Component relationships and interactions
+- **data-flow.md** - Data flow through the system
+- **deployment-architecture.md** - AWS infrastructure layout
+
+## Guidelines
+
+- Include diagrams where helpful (store in `assets/images/`)
+- Link to relevant ADRs for architectural decisions
+- Keep documents updated as the system evolves
+- Use consistent terminology and naming conventions

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,26 @@
+# Research
+
+Research findings, spikes, and evaluation results.
+
+## Research Index
+
+*Research documents will be added here as they are created.*
+
+## Naming Convention
+
+Use the format: `YYYY-MM-topic-description.md`
+
+Examples:
+- `2025-08-database-comparison.md`
+- `2025-08-authentication-spike.md`
+- `2025-08-performance-testing-results.md`
+
+## Research Template
+
+When documenting research, include:
+
+- **Objective** - What question are we trying to answer?
+- **Approach** - How did we conduct the research?
+- **Findings** - What did we discover?
+- **Recommendations** - What should we do based on the findings?
+- **Next Steps** - Follow-up actions or additional research needed

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,22 @@
+# Runbooks
+
+Operational procedures and troubleshooting guides.
+
+## Available Runbooks
+
+*Runbooks will be added here as they are created.*
+
+## Planned Runbooks
+
+- **deployment.md** - Deployment procedures and rollback steps
+- **monitoring.md** - Monitoring setup and alert responses
+- **troubleshooting.md** - Common issues and solutions
+- **backup-recovery.md** - Backup and recovery procedures
+
+## Runbook Guidelines
+
+- Include step-by-step procedures
+- Provide clear prerequisites and assumptions
+- Include rollback procedures where applicable
+- Add troubleshooting steps for common failures
+- Keep procedures updated and tested

--- a/docs/technical-specs/README.md
+++ b/docs/technical-specs/README.md
@@ -1,0 +1,18 @@
+# Technical Specifications
+
+Index of all technical specifications and feature documentation.
+
+## Available Specifications
+
+*Technical specifications will be added here as they are created.*
+
+## Template
+
+When creating new technical specifications, include:
+
+- **Purpose** - What problem does this solve?
+- **Requirements** - Functional and non-functional requirements
+- **Design** - High-level design approach
+- **Implementation** - Technical implementation details
+- **Testing** - Test strategy and acceptance criteria
+- **Dependencies** - External dependencies and integrations


### PR DESCRIPTION
## Summary
- Implements comprehensive docs/ directory structure per WS-21 specification
- Updates CLAUDE.md documentation workflow to use repo-based docs instead of Confluence
- Removes external Confluence dependencies from workflow
- Prepares documentation structure for future GitHub Pages publishing

## Changes Made
- Created docs/ directory with organized subdirectories:
  - `technical-specs/` - Technical specifications and feature documentation
  - `research/` - Research findings and spike results
  - `architecture/` - System architecture and design documents
  - `ADR/` - Architecture Decision Records with template
  - `runbooks/` - Operational procedures and troubleshooting
- Updated CLAUDE.md documentation strategy section
- Removed Confluence tool configuration and references
- Added proper README files with guidelines for each documentation type

## Benefits
- Version-controlled documentation alongside code
- GitHub Pages compatibility with relative markdown links
- Simplified workflow without external tool dependencies
- Better maintainability and searchability

## Testing
- Validated directory structure creation
- Confirmed all README files contain proper guidance
- Updated project structure in CLAUDE.md matches implementation

🤖 Generated with [Claude Code](https://claude.ai/code)